### PR TITLE
Don't use ...args in log function

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,8 @@ module.exports = function (callback, options) {
   const firstCheck = Date.now();
   const fpsTarget = 1000 / framerateTarget;
 
-  function log(...args) {
-    if (debug) console.log(...args);
+  function log() {
+    if (debug) console.log.apply(console, arguments);
   }
 
   function checkLoad() {


### PR DESCRIPTION
Babel compiles the `log` function to:

```js
function log() {
    if (debug) console.log.apply(arguments)
}
```

...which blows up in IE because `arguments` isn't a valid calling object.